### PR TITLE
Fix incorrect old/new name in combinediff

### DIFF
--- a/src/interdiff.c
+++ b/src/interdiff.c
@@ -1058,7 +1058,7 @@ output_delta (FILE *p1, FILE *p2, FILE *out)
 		if (getline (&oldname, &namelen, p1) < 0)
 			error (EXIT_FAILURE, errno, "Bad patch #1");
 
-	} while (strncmp (oldname, "+++ ", 4));
+	} while (strncmp (oldname, "--- ", 4));
 	oldname[strlen (oldname) - 1] = '\0';
 
 	do {


### PR DESCRIPTION
This fixes https://github.com/twaugh/patchutils/issues/53

I apologize I don't have time to write tests! Hopefully this should be somewhat obviously correct (or incorrect) since it's a one line fix.